### PR TITLE
cryptsetup: fix paths for loop devices

### DIFF
--- a/packages/cryptsetup/build.sh
+++ b/packages/cryptsetup/build.sh
@@ -2,5 +2,6 @@ TERMUX_PKG_HOMEPAGE=https://gitlab.com/cryptsetup/cryptsetup/
 TERMUX_PKG_DESCRIPTION="Userspace setup tool for transparent encryption of block devices using dm-crypt"
 TERMUX_PKG_DEPENDS="json-c, libdevmapper, libgcrypt, libpopt, libuuid"
 TERMUX_PKG_VERSION=2.0.3
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://www.kernel.org/pub/linux/utils/cryptsetup/v2.0/cryptsetup-${TERMUX_PKG_VERSION}.tar.xz
 TERMUX_PKG_SHA256=4d6cca04c1f5ff4a68d045d190efb2623087eda0274ded92f92a4b6911e501d4

--- a/packages/cryptsetup/fix-loopdev-path.patch
+++ b/packages/cryptsetup/fix-loopdev-path.patch
@@ -1,0 +1,21 @@
+diff -uNr cryptsetup-2.0.3/lib/utils_loop.c cryptsetup-2.0.3.mod/lib/utils_loop.c
+--- cryptsetup-2.0.3/lib/utils_loop.c	2018-02-28 11:20:59.000000000 +0200
++++ cryptsetup-2.0.3.mod/lib/utils_loop.c	2018-05-26 19:02:53.546906033 +0300
+@@ -57,7 +57,7 @@
+ 	struct loop_info64 lo64 = {0};
+ 
+ 	for (i = 0; i < 256; i++) {
+-		sprintf(dev, "/dev/loop%d", i);
++		sprintf(dev, "/dev/block/loop%d", i);
+ 
+ 		loop_fd = open(dev, O_RDONLY);
+ 		if (loop_fd < 0)
+@@ -91,7 +91,7 @@
+ 	}
+ 	close(loop_fd);
+ 
+-	if (sprintf(dev, "/dev/loop%d", i) < 0)
++	if (sprintf(dev, "/dev/block/loop%d", i) < 0)
+ 		return NULL;
+ 
+ 	if (stat(dev, &st) || !S_ISBLK(st.st_mode))


### PR DESCRIPTION
On Android, loop devices are located under /dev/block.