### PR TITLE
Provide full fingerprint and remove trusted=yes in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Run these steps on your termux device:
 # Needed by apt-key:
 pkg install dirmngr
 # Download key from keyserver:
-apt-key adv --keyserver pgp.mit.edu --recv A46BE53C
+apt-key adv --keyserver pgp.mit.edu --recv 9B4E7D27395024EA5A4FC6395AAAC9E0A46BE53C
 mkdir -p $PREFIX/etc/apt/sources.list.d
 # Setup repo:
 echo "deb [trusted=yes] https://grimler.se root stable" > $PREFIX/etc/apt/sources.list.d/termux-root.list

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ pkg install dirmngr
 apt-key adv --keyserver pgp.mit.edu --recv 9B4E7D27395024EA5A4FC6395AAAC9E0A46BE53C
 mkdir -p $PREFIX/etc/apt/sources.list.d
 # Setup repo:
-echo "deb [trusted=yes] https://grimler.se root stable" > $PREFIX/etc/apt/sources.list.d/termux-root.list
+echo "deb https://grimler.se root stable" > $PREFIX/etc/apt/sources.list.d/termux-root.list
 apt update
 ```
 


### PR DESCRIPTION
Short key id's are considered insecure and shouldn't be used anymore.
 [trusted=yes] circumvents this whole signing process and accepts whatever key. It should only be used for testing purposes and is considered very insecure. Also if the users bothers to import the key anyway he doesn't need to trust the repository manually. 