### PR TITLE
update several packages (and links, and many more misc changes)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "termux-packages"]
 	path = termux-packages
-	url = git@github.com:termux/termux-packages
+	url = https://github.com/termux/termux-packages

--- a/README.md
+++ b/README.md
@@ -1,31 +1,30 @@
 # Termux root packages
-This repository contain packages that are useful for rooted users only.
+This repository contains packages that are only useful for rooted users.
 
 # Building a package
-To build a package, checkout the termux-root-packages
+To build a package, first clone termux-root-packages,
 ```sh
 git clone https://github.com/termux/termux-root-packages
 ```
-and then update the termux-packages submodule
+and then update the termux-packages submodule.
 ```sh
 cd termux-root-packages
 git submodule init
 git submodule update
 ```
-You can then build a package with
+You can then build a package with the following:
 ```sh
 ./build-root-package.sh name-of-package
 ```
 Note that this currently only works outside of the docker container.
-To build from the docker container termux-root-packages have to be a subfolder of termux-packages, and a root package can then be built with
+To build from the docker container, termux-root-packages has to be a subfolder of termux-packages, and a root package can then be built with
 ```sh
 ./build-package.sh termux-root-packages/packages/package-to-build
 ```
-The termux-package submodule is then not needed.
+The termux-package submodule is no longer needed after this.
 
 # Subscribing to the repository
-To install packages from this repository you need to subscribe to it with:
+To install packages from this repository, you need to subscribe to it with:
 ```sh
 pkg install root-repo
 ```
-

--- a/build-root-package.sh
+++ b/build-root-package.sh
@@ -4,7 +4,7 @@ set -e -o pipefail -u
 
 # link into main package repo to handle dependencies
 for root_package in packages/*; do
-    ln -sf ../../$root_package termux-packages/packages/
+    ln -sf ../../${root_package} termux-packages/packages/
 done
 
 cd termux-packages

--- a/packages/aircrack-ng/build.sh
+++ b/packages/aircrack-ng/build.sh
@@ -1,10 +1,12 @@
-TERMUX_PKG_HOMEPAGE=https://www.aircrack-ng.org
-TERMUX_PKG_DESCRIPTION="an 802.11 WEP and WPA-PSK keys cracking program"
-TERMUX_PKG_VERSION=1.2-rc4
-TERMUX_PKG_REVISION=3
-TERMUX_PKG_SRCURL=https://download.aircrack-ng.org/aircrack-ng-${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=d93ac16aade5b4d37ab8cdf6ce4b855835096ccf83deb65ffdeff6d666eaff36
 TERMUX_PKG_MAINTAINER="Auxilus @Auxilus"
+TERMUX_PKG_HOMEPAGE=https://www.aircrack-ng.org/
+TERMUX_PKG_DESCRIPTION="WiFi security auditing tools suite"
+TERMUX_PKG_VERSION=1.2-rc4 #1.5.1 (requires autoconf, automake, libtool, shtool, pkg-config (and maybe libstdc and make/gmake) support)
+TERMUX_PKG_REVISION=4
+TERMUX_PKG_SRCURL=https://github.com/aircrack-ng/aircrack-ng/archive/${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=ed241ea423cab1c86e7882e901d5200d91b2f97d7efd703b0acf17742be47f9b
 TERMUX_PKG_DEPENDS="libnl, openssl, libpcap, pciutils"
 TERMUX_PKG_BUILD_DEPENDS="libnl-dev, openssl-dev, libpcap-dev"
 TERMUX_PKG_BUILD_IN_SRC=yes
+
+# TODO: in termux-packages, add support for these packages: shtool, libstdc, gmake

--- a/packages/arp-scan/build.sh
+++ b/packages/arp-scan/build.sh
@@ -1,12 +1,12 @@
 TERMUX_PKG_HOMEPAGE=https://github.com/royhills/arp-scan
 TERMUX_PKG_DESCRIPTION="arp-scan is a command-line tool for system discovery and fingerprinting. It constructs and sends ARP requests to the specified IP addresses, and displays any responses that are received."
-TERMUX_PKG_VERSION=1.9
-TERMUX_PKG_SHA256=b2a446a170e4a2feeb825cd08db48a147f8dffae702077f33e456c4200e7afb0
-TERMUX_PKG_SRCURL=https://github.com/royhills/arp-scan/archive/$TERMUX_PKG_VERSION.tar.gz
-TERMUX_PKG_DEPENDS="libpcap"
+TERMUX_PKG_VERSION=1.9.5
+TERMUX_PKG_SRCURL=https://github.com/royhills/arp-scan/archive/${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=aa9498af84158a315b7e0ea6c2cddfa746660ca3987cbe7e32c0c90f5382d9d2
+TERMUX_PKG_DEPENDS="libpcap" #make
 TERMUX_PKG_BUILD_DEPENDS="libpcap-dev"
 
-if [ $TERMUX_ARCH_BITS == 32 ]; then
+if [[ ${TERMUX_ARCH_BITS} == 32 ]]; then
     # Retrieved from compilation on device:
     TERMUX_PKG_EXTRA_CONFIGURE_ARGS+="pgac_cv_snprintf_long_long_int_format=%lld"
 fi

--- a/packages/cryptsetup/build.sh
+++ b/packages/cryptsetup/build.sh
@@ -1,7 +1,7 @@
 TERMUX_PKG_HOMEPAGE=https://gitlab.com/cryptsetup/cryptsetup/
 TERMUX_PKG_DESCRIPTION="Userspace setup tool for transparent encryption of block devices using dm-crypt"
+TERMUX_PKG_VERSION=2.0.6
+TERMUX_PKG_REVISION=2
+TERMUX_PKG_SRCURL=https://mirrors.edge.kernel.org/pub/linux/utils/cryptsetup/v2.0/cryptsetup-${TERMUX_PKG_VERSION}.tar.xz
+TERMUX_PKG_SHA256=7c51fae0f0e7ea9af0f515b2ac77009fb2969a6619ebab47d097dca38b083d30
 TERMUX_PKG_DEPENDS="json-c, libdevmapper, libgcrypt, libpopt, libuuid"
-TERMUX_PKG_VERSION=2.0.3
-TERMUX_PKG_REVISION=1
-TERMUX_PKG_SRCURL=https://www.kernel.org/pub/linux/utils/cryptsetup/v2.0/cryptsetup-${TERMUX_PKG_VERSION}.tar.xz
-TERMUX_PKG_SHA256=4d6cca04c1f5ff4a68d045d190efb2623087eda0274ded92f92a4b6911e501d4

--- a/packages/dnsmasq/build.sh
+++ b/packages/dnsmasq/build.sh
@@ -1,6 +1,6 @@
 TERMUX_PKG_HOMEPAGE=http://www.thekelleys.org.uk/dnsmasq/doc.html
-TERMUX_PKG_DESCRIPTION="Dnsmasq provides network infrastructure for small networks: DNS, DHCP, router advertisement and network boot"
-TERMUX_PKG_VERSION=2.79
-TERMUX_PKG_SHA256=78ad74f5ca14fd85a8bac93f764cd9d60b27579e90eabd3687ca7b030e67861f
-TERMUX_PKG_SRCURL=http://www.thekelleys.org.uk/dnsmasq/dnsmasq-$TERMUX_PKG_VERSION.tar.xz
+TERMUX_PKG_DESCRIPTION="Dnsmasq provides network infrastructure for small networks"
+TERMUX_PKG_VERSION=2.80
+TERMUX_PKG_SRCURL=http://www.thekelleys.org.uk/dnsmasq/dnsmasq-${TERMUX_PKG_VERSION}.tar.xz
+TERMUX_PKG_SHA256=cdaba2785e92665cf090646cba6f94812760b9d7d8c8d0cfb07ac819377a63bb
 TERMUX_PKG_BUILD_IN_SRC=YES

--- a/packages/encfs/build.sh
+++ b/packages/encfs/build.sh
@@ -1,6 +1,6 @@
-TERMUX_PKG_MAINTINER="Henrik Grimler @Grimler91"
+TERMUX_PKG_MAINTAINER="Henrik Grimler @Grimler91"
 TERMUX_PKG_HOMEPAGE=https://github.com/vgough/encfs
-TERMUX_PKG_DESCRIPTION="EncFS provides an encrypted filesystem in user-space"
+TERMUX_PKG_DESCRIPTION="An encrypted filesystem for FUSE"
 TERMUX_PKG_VERSION=1.9.5
 TERMUX_PKG_SHA256=4709f05395ccbad6c0a5b40a4619d60aafe3473b1a79bafb3aa700b1f756fd63
 TERMUX_PKG_DEPENDS="libfuse, openssl"

--- a/packages/ethtool/build.sh
+++ b/packages/ethtool/build.sh
@@ -1,9 +1,9 @@
-TERMUX_PKG_HOMEPAGE=hhttps://www.kernel.org/pub/software/network/ethtool/
-TERMUX_PKG_DESCRIPTION="standard Linux utility for controlling network drivers and hardware, particularly for wired Ethernet devices"
-TERMUX_PKG_VERSION=4.11
-TERMUX_PKG_REVISION=1
-TERMUX_PKG_SRCURL=https://www.kernel.org/pub/software/network/ethtool/ethtool-${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=af2fd9692f3159d3ab1e41e6f9b7d8db2a4693f1cb22348c88ba89f70f0e6503
 TERMUX_PKG_MAINTAINER="Auxilus @Auxilus"
+TERMUX_PKG_HOMEPAGE=https://mirrors.edge.kernel.org/pub/software/network/ethtool/
+TERMUX_PKG_DESCRIPTION="standard Linux utility for controlling network drivers and hardware, particularly for wired Ethernet devices"
+TERMUX_PKG_VERSION=4.19
+TERMUX_PKG_REVISION=1
+TERMUX_PKG_SRCURL=https://mirrors.edge.kernel.org/pub/software/network/ethtool/ethtool-${TERMUX_PKG_VERSION}.tar.xz
+TERMUX_PKG_SHA256=b18a6c364e42c29cdac057cf183c9674163db96b30848adfa8c2a90450f6d0c8
 TERMUX_PKG_DEPENDS="libnl" 
 TERMUX_PKG_BUILD_IN_SRC=yes

--- a/packages/frida-server/build.sh
+++ b/packages/frida-server/build.sh
@@ -1,40 +1,47 @@
-TERMUX_PKG_HOMEPAGE=https://www.frida.re
+TERMUX_PKG_HOMEPAGE=https://www.frida.re/
 TERMUX_PKG_DESCRIPTION="Dynamic instrumentation toolkit for developers, reverse-engineers, and security researchers"
 _MAJOR_VERSION=12
 _MINOR_VERSION=2
-_MICRO_VERSION=14
+_MICRO_VERSION=26
 TERMUX_PKG_VERSION=()
 TERMUX_PKG_SHA256=()
-TERMUX_PKG_VERSION+=($_MAJOR_VERSION.$_MINOR_VERSION.$_MICRO_VERSION) # frida
+TERMUX_PKG_VERSION+=(${_MAJOR_VERSION}.$_MINOR_VERSION.$_MICRO_VERSION) # frida
 # Sort of abusive use of $TERMUX_PKG_VERSION:
 TERMUX_PKG_VERSION+=(7388bf76dc65d1962d7d514c92de8d6be7555599) # capstone
-TERMUX_PKG_VERSION+=(6193db218e9f31cfe2246bdd48afd13a20147a8a) # frida-core
-TERMUX_PKG_VERSION+=(2d62e31310ffe0473a29f5cfbbab10f79e2825bb) # frida-gum
-TERMUX_PKG_VERSION+=(2ed895b881f69206df28854791ffb84d301709a6) # frida-python
 TERMUX_PKG_VERSION+=(7754b239601babc0dcbad4f8ee31681235981adb) # frida-clr
+TERMUX_PKG_VERSION+=(56b8b55815c67b1fa7b5c483bf92e1724c600175) # frida-core
+TERMUX_PKG_VERSION+=(a1cdb28e16ff2888c582ddd34b939a6d2b2146d1) # frida-gum
+TERMUX_PKG_VERSION+=(cb736c69c7d47ee447515f78d476a3e9de525712) # frida-node
+TERMUX_PKG_VERSION+=(5c2dc4da5549c9c30e7af944281fb3c6033c2c4c) # frida-python
 TERMUX_PKG_VERSION+=(6e7b9a55b5b59b32e601f6934c2d0a6e3c299161) # frida-qml
 TERMUX_PKG_VERSION+=(2c9cc1f87b839b8621afdfce43e44da29deaafab) # frida-swift
+TERMUX_PKG_VERSION+=(cb3df03d31c3f801745485787e5dc9e42809a230) # frida-tools
 TERMUX_PKG_VERSION+=(931f387786fbc92fa9c678bf72b60fc040ce895a) # releng/meson
 
-TERMUX_PKG_SHA256+=(44a8c6f2b2f507485e1f2000e7f715b08df57c71b5421f3f803413c8453bb9d0) # frida
+TERMUX_PKG_SHA256+=(c70b70be06c65252c3e5d914101186ade61eb4a6214f4b29e80ad3deecb27557) # frida
 TERMUX_PKG_SHA256+=(43ef0cc72fc19b72393be94d01dcad48835f98a72475aea8187f47ff8475014d) # capstone
+TERMUX_PKG_SHA256+=(f5ff752bc03de0c795bc213f04516c6f880a151955bf2b45520b599be472ad56) # frida-clr
 TERMUX_PKG_SHA256+=(07ee95b8714ab73e66496b27074319c7fa5a4872184a10492ee6b1d387f46dbe) # frida-core
-TERMUX_PKG_SHA256+=(a684c9e5adada5af1247fd26fd916e0f0bc525d4f1a51c512a5c46f18f1c0a75) # frida-gum
-TERMUX_PKG_SHA256+=(32f0e9108c7a09f6ffff7c542dcc6352a48c852186bb59d8ff384298bf105ba7) # frida-python
-TERMUX_PKG_SHA256+=(0a60f97a32ea1c926b5bf060a822a0d6d44f5e047b80269e7ea6fbc16a178640) # frida-clr
+TERMUX_PKG_SHA256+=(1d17ffb57936dafd29f4745535a3327af191fcbdc45211fee87abd91662e3ca1) # frida-gum
+TERMUX_PKG_SHA256+=(fbf0c770d6e38f5cd60b3f0616c495a62da3fd25b5f67b9816ef1024dce82246) # frida-node
+TERMUX_PKG_SHA256+=(0bffd060a0f8c1bf1ad7b1837c10fc2d39ea2854861b7727f5336bb173e12cea) # frida-python
 TERMUX_PKG_SHA256+=(c65eb620a879e386268b50e1369c808c0dd92fdcac711b15fb3089b1c1493af9) # frida-qml
 TERMUX_PKG_SHA256+=(9e5fe8463dfaa829d95787a77f613eef45e15e094e54e7df3c944acedbd76693) # frida-swift
+TERMUX_PKG_SHA256+=(b5476b10cdc1bc930154c52203a89fae8539432c49575e21551d4e1425252dae) # frida-tools
 TERMUX_PKG_SHA256+=(42fc33147373f7ee8293486a420d32abc7aea956adfba5c7e98ccdacb1c6cf07) # releng/meson
-_modules=(frida capstone frida-core frida-gum frida-python frida-clr frida-qml frida-swift meson)
+
+_modules=(frida capstone frida-clr frida-core frida-gum frida-node frida-python frida-qml frida-swift frida-tools meson)
 TERMUX_PKG_SRCURL=(https://github.com/frida/frida/archive/$TERMUX_PKG_VERSION.tar.gz
 		   https://github.com/frida/capstone/archive/${TERMUX_PKG_VERSION[1]}.zip
-		   https://github.com/frida/frida-core/archive/${TERMUX_PKG_VERSION[2]}.zip
-		   https://github.com/frida/frida-gum/archive/${TERMUX_PKG_VERSION[3]}.zip
-		   https://github.com/frida/frida-python/archive/${TERMUX_PKG_VERSION[4]}.zip
-		   https://github.com/frida/frida-clr/archive/${TERMUX_PKG_VERSION[5]}.zip
-		   https://github.com/frida/frida-qml/archive/${TERMUX_PKG_VERSION[6]}.zip
-		   https://github.com/frida/frida-swift/archive/${TERMUX_PKG_VERSION[7]}.zip
-		   https://github.com/frida/meson/archive/${TERMUX_PKG_VERSION[8]}.zip)
+		   https://github.com/frida/frida-clr/archive/${TERMUX_PKG_VERSION[2]}.zip
+		   https://github.com/frida/frida-core/archive/${TERMUX_PKG_VERSION[3]}.zip
+		   https://github.com/frida/frida-gum/archive/${TERMUX_PKG_VERSION[4]}.zip
+		   https://github.com/frida/frida-node/archive/${TERMUX_PKG_VERSION[5]}.zip
+		   https://github.com/frida/frida-python/archive/${TERMUX_PKG_VERSION[6]}.zip
+		   https://github.com/frida/frida-qml/archive/${TERMUX_PKG_VERSION[7]}.zip
+		   https://github.com/frida/frida-swift/archive/${TERMUX_PKG_VERSION[8]}.zip
+		   https://github.com/frida/frida-tools/archive/${TERMUX_PKG_VERSION[9]}.zip
+		   https://github.com/frida/meson/archive/${TERMUX_PKG_VERSION[10]}.zip)
 
 TERMUX_PKG_MAINTAINER="Henrik Grimler @Grimler91"
 TERMUX_PKG_BUILD_IN_SRC=yes
@@ -42,11 +49,11 @@ TERMUX_PKG_EXTRA_MAKE_ARGS="ANDROID_NDK_ROOT=$HOME/lib/android-ndk"
 TERMUX_PKG_HOSTBUILD=yes
 
 termux_step_host_build () {
-	local node_version=8.12.0
+	local node_version=8.14.0 #9.11.2
 	termux_download https://nodejs.org/dist/v${node_version}/node-v${node_version}-linux-x64.tar.xz \
-			$TERMUX_PKG_CACHEDIR/node-v${node_version}-linux-x64.tar.xz \
-			29a20479cd1e3a03396a4e74a1784ccdd1cf2f96928b56f6ffa4c8dae40c88f2
-	tar -xf $TERMUX_PKG_CACHEDIR/node-v${node_version}-linux-x64.tar.xz --strip-components=1
+			${TERMUX_PKG_CACHEDIR}/node-v${node_version}-linux-x64.tar.xz \
+			a56d1af4d7da81504338b09809cf10b3144808d47d4117b9bd9a5a4ec4d5d9b9
+	tar -xf ${TERMUX_PKG_CACHEDIR}/node-v${node_version}-linux-x64.tar.xz --strip-components=1
 }
 
 termux_step_post_extract_package () {
@@ -54,34 +61,34 @@ termux_step_post_extract_package () {
 	for i in $(seq 1 $(( ${#_modules[@]}-1 ))); do
 		rm -rf ${_modules[$i]}
 		mv ${_modules[$i]}-${TERMUX_PKG_VERSION[$i]} ${_modules[$i]}
-		echo ${TERMUX_PKG_VERSION[$i]} > $TERMUX_PKG_SRCDIR/build/.${_modules[$i]}-submodule-stamp
+		echo ${TERMUX_PKG_VERSION[$i]} > ${TERMUX_PKG_SRCDIR}/build/.${_modules[$i]}-submodule-stamp
 	done
 	mv meson releng/
 }
 
 termux_step_post_configure () {
 	# frida-version.h is normally generated from git and the commits.
-	sed -i "s/@TERMUX_PKG_VERSION@/$TERMUX_PKG_VERSION/g" $TERMUX_PKG_SRCDIR/build/frida-version.h
-	sed -i "s/@_MAJOR_VERSION@/$_MAJOR_VERSION/g" $TERMUX_PKG_SRCDIR/build/frida-version.h
-	sed -i "s/@_MINOR_VERSION@/$_MINOR_VERSION/g" $TERMUX_PKG_SRCDIR/build/frida-version.h
-	sed -i "s/@_MICRO_VERSION@/$_MICRO_VERSION/g" $TERMUX_PKG_SRCDIR/build/frida-version.h
+	sed -i "s/@TERMUX_PKG_VERSION@/$TERMUX_PKG_VERSION/g" ${TERMUX_PKG_SRCDIR}/build/frida-version.h
+	sed -i "s/@_MAJOR_VERSION@/$_MAJOR_VERSION/g" ${TERMUX_PKG_SRCDIR}/build/frida-version.h
+	sed -i "s/@_MINOR_VERSION@/$_MINOR_VERSION/g" ${TERMUX_PKG_SRCDIR}/build/frida-version.h
+	sed -i "s/@_MICRO_VERSION@/$_MICRO_VERSION/g" ${TERMUX_PKG_SRCDIR}/build/frida-version.h
 }
 
 termux_step_make () {
-	if [ $TERMUX_ARCH == "aarch64" ]; then
+	if [[ ${TERMUX_ARCH} == "aarch64" ]]; then
 		arch=arm64
-	elif [ $TERMUX_ARCH == "i686" ]; then
+	elif [[ ${TERMUX_ARCH} == "i686" ]]; then
 		arch=x86
 	else
-		arch=$TERMUX_ARCH
+		arch=${TERMUX_ARCH}
 	fi
 	# Build only for desired architecture:
-	sed -i "s/@TERMUX_ARCH@/$arch/g" $TERMUX_PKG_SRCDIR/Makefile.linux.mk
-	PATH=$TERMUX_PKG_HOSTBUILD_DIR/bin:$PATH make server-android ${TERMUX_PKG_EXTRA_MAKE_ARGS}
+	sed -i "s/@TERMUX_ARCH@/$arch/g" ${TERMUX_PKG_SRCDIR}/Makefile.linux.mk
+	PATH=${TERMUX_PKG_HOSTBUILD_DIR}/bin:$PATH make server-android ${TERMUX_PKG_EXTRA_MAKE_ARGS}
 }
 
 termux_step_make_install () {
 	# Only include frida-server and frida-inject. Is something else useful?
-	install $TERMUX_PKG_BUILDDIR/build/frida-android-$arch/bin/frida-server $TERMUX_PREFIX/bin/
-	install $TERMUX_PKG_BUILDDIR/build/frida-android-$arch/bin/frida-inject $TERMUX_PREFIX/bin/
+	install ${TERMUX_PKG_BUILDDIR}/build/frida-android-${arch}/bin/frida-server ${TERMUX_PREFIX}/bin/
+	install ${TERMUX_PKG_BUILDDIR}/build/frida-android-${arch}/bin/frida-inject ${TERMUX_PREFIX}/bin/
 }

--- a/packages/hping3/build.sh
+++ b/packages/hping3/build.sh
@@ -1,14 +1,14 @@
-TERMUX_PKG_HOMEPAGE=http://www.hping.org
+TERMUX_PKG_HOMEPAGE=http://www.hping.org/
 TERMUX_PKG_DESCRIPTION="hping is a command-line oriented TCP/IP packet assembler/analyzer."
 # Same versioning as archlinux:
 TERMUX_PKG_VERSION=3.0.0
-TERMUX_PKG_BUILD_IN_SRC="yes"
+TERMUX_PKG_SRCURL=http://www.hping.org/hping3-20051105.tar.gz
+TERMUX_PKG_SHA256=f5a671a62a11dc8114fa98eade19542ed1c3aa3c832b0e572ca0eb1a5a4faee8
 TERMUX_PKG_DEPENDS="libandroid-shmem, libpcap, tcl"
 TERMUX_PKG_BUILD_DEPENDS="libpcap-dev, tcl-dev"
-TERMUX_PKG_SHA256=f5a671a62a11dc8114fa98eade19542ed1c3aa3c832b0e572ca0eb1a5a4faee8
-TERMUX_PKG_SRCURL=http://www.hping.org/hping3-20051105.tar.gz
+TERMUX_PKG_BUILD_IN_SRC=yes
 
 termux_step_post_configure () {
 	export LDFLAGS+=" -landroid-shmem"
-	mkdir -p $TERMUX_PREFIX/share/man/man8
+	mkdir -p ${TERMUX_PREFIX}/share/man/man8
 }

--- a/packages/iw/build.sh
+++ b/packages/iw/build.sh
@@ -1,8 +1,8 @@
 TERMUX_PKG_HOMEPAGE=https://wireless.wiki.kernel.org/en/users/documentation/iw
 TERMUX_PKG_DESCRIPTION="CLI configuration utility for wireless devices"
-TERMUX_PKG_VERSION=4.9
-TERMUX_PKG_SRCURL=https://www.kernel.org/pub/software/network/iw/iw-${TERMUX_PKG_VERSION}.tar.xz
-TERMUX_PKG_SHA256=324cc805fad52cba2c16b9ab569906889fb645cc962aac4cfda1db85d2de97ce
+TERMUX_PKG_VERSION=4.14
+TERMUX_PKG_SRCURL=https://mirrors.edge.kernel.org/pub/software/network/iw/iw-${TERMUX_PKG_VERSION}.tar.xz
+TERMUX_PKG_SHA256=f01671c0074bfdec082a884057edba1b9efd35c89eda554638496f03b769ad89
 TERMUX_PKG_MAINTAINER="Auxilus @Auxilus"
 TERMUX_PKG_DEPENDS="libnl, libnl-dev, pkg-config"
 TERMUX_PKG_BUILD_IN_SRC=yes

--- a/packages/libdevmapper/build.sh
+++ b/packages/libdevmapper/build.sh
@@ -1,9 +1,9 @@
-TERMUX_PKG_HOMEPAGE=http://sourceware.org/lvm2/
+TERMUX_PKG_HOMEPAGE=https://sourceware.org/lvm2/
 TERMUX_PKG_DESCRIPTION="A device-mapper library from LVM2 package"
 TERMUX_PKG_DEPENDS="libandroid-support"
-TERMUX_PKG_VERSION=2.02.177
+TERMUX_PKG_VERSION=2.03.00
 TERMUX_PKG_SRCURL=https://mirrors.kernel.org/sourceware/lvm2/releases/LVM2.${TERMUX_PKG_VERSION}.tgz
-TERMUX_PKG_SHA256=4025a23ec9b15c2cb7486d151c29dc953b75efc4d452cfe9dbbc7c0fac8e80f2
+TERMUX_PKG_SHA256=405992bf76960e60c7219d84d5f1e22edc34422a1ea812e21b2ac3c813d0da4e
 TERMUX_PKG_BUILD_IN_SRC=yes
 
 termux_step_make() {

--- a/packages/libfuse/build.sh
+++ b/packages/libfuse/build.sh
@@ -1,7 +1,7 @@
-TERMUX_PKG_MAINTINER="Henrik Grimler @Grimler91"
+TERMUX_PKG_MAINTAINER="Henrik Grimler @Grimler91"
 TERMUX_PKG_HOMEPAGE=https://github.com/libfuse/libfuse
 TERMUX_PKG_DESCRIPTION="FUSE (Filesystem in Userspace) is an interface for userspace programs to export a filesystem to the Linux kernel"
-TERMUX_PKG_VERSION=2.9.8
+TERMUX_PKG_VERSION=2.9.8 #3.3.0
 TERMUX_PKG_SHA256=ceadc28f033b29d7aa1d7c3a5a267d51c2b572ed4e7346e0f9e24f4f5889debb
 TERMUX_PKG_SRCURL=https://github.com/libfuse/libfuse/archive/fuse-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="

--- a/packages/libusb/build.sh
+++ b/packages/libusb/build.sh
@@ -1,8 +1,8 @@
-TERMUX_PKG_HOMEPAGE=http://libusb.info/
-TERMUX_PKG_DESCRIPTION="A cross-platform user library to access USB devices"
+TERMUX_PKG_HOMEPAGE=https://libusb.info/
+TERMUX_PKG_DESCRIPTION="A C library that provides generic access to USB devices"
 TERMUX_PKG_VERSION=1.0.22
-TERMUX_PKG_SRCURL=https://github.com/libusb/libusb/archive/v${TERMUX_PKG_VERSION}.zip
-TERMUX_PKG_SHA256=cb10afc04399f5aa15cce246e5f043bea3547d128f088d62874039f984db7879
+TERMUX_PKG_SRCURL=https://github.com/libusb/libusb/archive/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=3500f7b182750cd9ccf9be8b1df998f83df56a39ab264976bdb3307773e16f48
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--disable-udev"
 
 termux_step_pre_configure() {

--- a/packages/mtr/build.sh
+++ b/packages/mtr/build.sh
@@ -2,14 +2,14 @@ TERMUX_PKG_HOMEPAGE=https://github.com/traviscross/mtr
 TERMUX_PKG_DESCRIPTION="Network diagnostic tool"
 TERMUX_PKG_VERSION=0.92
 TERMUX_PKG_REVISION=1
-TERMUX_PKG_SHA256=568a52911a8933496e60c88ac6fea12379469d7943feb9223f4337903e4bc164
 TERMUX_PKG_SRCURL=https://github.com/traviscross/mtr/archive/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=568a52911a8933496e60c88ac6fea12379469d7943feb9223f4337903e4bc164
 TERMUX_PKG_DEPENDS="ncurses"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--without-gtk"
 
 termux_step_pre_configure() {
-	cp $TERMUX_PKG_BUILDER_DIR/hsearch/* $TERMUX_PKG_SRCDIR/portability
+	cp ${TERMUX_PKG_BUILDER_DIR}/hsearch/* ${TERMUX_PKG_SRCDIR}/portability
 
-	cd $TERMUX_PKG_SRCDIR
+	cd ${TERMUX_PKG_SRCDIR}
 	./bootstrap.sh
 }

--- a/packages/nethogs/build.sh
+++ b/packages/nethogs/build.sh
@@ -1,14 +1,15 @@
+TERMUX_PKG_MAINTAINER="Pierre Rudloff <contact@rudloff.pro>"
 TERMUX_PKG_HOMEPAGE=https://github.com/raboof/nethogs
 TERMUX_PKG_DESCRIPTION="Net top tool grouping bandwidth per process"
 TERMUX_PKG_VERSION=0.8.5
 TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=https://github.com/raboof/nethogs/archive/v${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_BUILD_IN_SRC=yes
+TERMUX_PKG_SHA256=6a9392726feca43228b3f0265379154946ef0544c2ca2cac59ec35a24f469dcc
 TERMUX_PKG_FOLDERNAME=nethogs-${TERMUX_PKG_VERSION}
 TERMUX_PKG_DEPENDS="ncurses, libpcap"
-TERMUX_PKG_MAINTAINER="Pierre Rudloff <contact@rudloff.pro>"
-TERMUX_PKG_SHA256=6a9392726feca43228b3f0265379154946ef0544c2ca2cac59ec35a24f469dcc
 TERMUX_PKG_EXTRA_MAKE_ARGS="nethogs"
+TERMUX_PKG_BUILD_IN_SRC=yes
+
 termux_step_pre_configure () {
 	export CPPFLAGS="$CPPFLAGS -Wno-c++11-narrowing"
 }

--- a/packages/pciutils/build.sh
+++ b/packages/pciutils/build.sh
@@ -1,13 +1,13 @@
-TERMUX_PKG_HOMEPAGE=http://mj.ucw.cz/sw/pciutils/
-TERMUX_PKG_DESCRIPTION="The PCI Utilities are a collection of programs for inspecting and manipulating configuration of PCI devices"
+TERMUX_PKG_HOMEPAGE=https://mj.ucw.cz/sw/pciutils/
+TERMUX_PKG_DESCRIPTION="a collection of programs for inspecting and manipulating configuration of PCI devices"
 TERMUX_PKG_VERSION=3.6.2
-TERMUX_PKG_SRCURL=ftp://atrey.karlin.mff.cuni.cz/pub/linux/pci/pciutils-$TERMUX_PKG_VERSION.tar.gz
+TERMUX_PKG_SRCURL=ftp://atrey.karlin.mff.cuni.cz/pub/linux/pci/pciutils-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=30005e341bb0ffa734174e592dc8f0dd928e1c9368b859715812149ed91d8f93
 TERMUX_PKG_BUILD_IN_SRC=yes
 
 termux_step_pre_configure () {
-	local ARCH=$TERMUX_ARCH
-	if [ $ARCH == "arm" ]; then
+	local ARCH=${TERMUX_ARCH}
+	if [[ ${ARCH} == "arm" ]]; then
 		ARCH="armv7l"
 	fi
 

--- a/packages/squashfuse/build.sh
+++ b/packages/squashfuse/build.sh
@@ -1,5 +1,5 @@
 TERMUX_PKG_HOMEPAGE=https://github.com/vasi/squashfuse
-TERMUX_PKG_DESCRIPTION="Squashfuse lets you mount SquashFS archives in user-space"
+TERMUX_PKG_DESCRIPTION="FUSE filesystem to mount squashfs archives"
 TERMUX_PKG_VERSION=0.1.103
 TERMUX_PKG_SHA256=bba530fe435d8f9195a32c295147677c58b060e2c63d2d4204ed8a6c9621d0dd
 TERMUX_PKG_SRCURL=https://github.com/vasi/squashfuse/archive/${TERMUX_PKG_VERSION}.tar.gz

--- a/packages/tcpdump/build.sh
+++ b/packages/tcpdump/build.sh
@@ -1,8 +1,8 @@
-TERMUX_PKG_HOMEPAGE=http://www.tcpdump.org/
-TERMUX_PKG_DESCRIPTION="Powerful command-line packet analyzer"
+TERMUX_PKG_HOMEPAGE=https://www.tcpdump.org/
+TERMUX_PKG_DESCRIPTION="A powerful command-line packet analyzer"
 TERMUX_PKG_VERSION=4.9.2
 TERMUX_PKG_REVISION=1
-TERMUX_PKG_SRCURL=http://www.tcpdump.org/release/tcpdump-${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SRCURL=https://www.tcpdump.org/release/tcpdump-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=798b3536a29832ce0cbb07fafb1ce5097c95e308a6f592d14052e1ef1505fe79
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="ac_cv_linux_vers=3.4"
 TERMUX_PKG_RM_AFTER_INSTALL="bin/tcpdump.${TERMUX_PKG_VERSION}"

--- a/packages/tshark/build.sh
+++ b/packages/tshark/build.sh
@@ -1,9 +1,9 @@
-TERMUX_PKG_HOMEPAGE=https://www.aircrack-ng.org
-TERMUX_PKG_DESCRIPTION="network protocol analyzer and sniffer"
-TERMUX_PKG_VERSION=2.6.3
-TERMUX_PKG_SRCURL=https://www.wireshark.org/download/src/all-versions/wireshark-${TERMUX_PKG_VERSION}.tar.xz
-TERMUX_PKG_SHA256=d158a8a626dc0997a826cf12b5316a3d393fb9f93d84cc86e75b212f0044a3ec
 TERMUX_PKG_MAINTAINER="Auxilus @Auxilus"
+TERMUX_PKG_HOMEPAGE=https://www.aircrack-ng.org/
+TERMUX_PKG_DESCRIPTION="Network protocol analyzer and sniffer"
+TERMUX_PKG_VERSION=2.6.5
+TERMUX_PKG_SRCURL=https://www.wireshark.org/download/src/all-versions/wireshark-${TERMUX_PKG_VERSION}.tar.xz
+TERMUX_PKG_SHA256=93155b798544b2f07693920f4ac1b531c952965ee4eb1d98419961240177438a
 TERMUX_PKG_DEPENDS="glib, libgpg-error, libgcrypt, libnl, libpcap, openssl"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--with-qt=no
 --disable-wireshark
@@ -12,5 +12,5 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--with-qt=no
 
 termux_step_pre_configure () {
 	./autogen.sh
-	LDFLAGS+=" -L$TERMUX_PKG_BUILDDIR/wsutil/.libs -L$TERMUX_PKG_BUILDDIR/epan/.libs" #A bit hacky..
+	LDFLAGS+=" -L$TERMUX_PKG_BUILDDIR/wsutil/.libs -L$TERMUX_PKG_BUILDDIR/epan/.libs" #A bit hacky...
 }

--- a/packages/wireless-tools/build.sh
+++ b/packages/wireless-tools/build.sh
@@ -1,9 +1,8 @@
-TERMUX_PKG_HOMEPAGE=https://hewlettpackard.github.io/wireless-tools/Tools.html
-TERMUX_PKG_DESCRIPTION="Tools allowing to manipulate the Wireless Extensions"
+TERMUX_PKG_HOMEPAGE=https://hewlettpackard.github.io/wireless-tools/Tools
+TERMUX_PKG_DESCRIPTION="A set of tools allowing to manipulate the Wireless Extensions"
 TERMUX_PKG_VERSION=30pre9
 TERMUX_PKG_SRCURL=https://hewlettpackard.github.io/wireless-tools/wireless_tools.30.pre9.tar.gz
 TERMUX_PKG_SHA256=abd9c5c98abf1fdd11892ac2f8a56737544fe101e1be27c6241a564948f34c63
-
 TERMUX_PKG_BUILD_IN_SRC=yes
 
 termux_step_make () {


### PR DESCRIPTION
### General
- Fix English in README.md
- Update termux-packages submodule to 05251c67a65d99731802699d56176342c3bb4277
- Simple variable usage in files (i.e. wrapping in {}) and double brackets
- Update a bunch of outdated links (whether it be homepage, or srcurl links)
- Fixed several misspellings of "maintainer" (was "maintiner")
- Rearranged some things

### Package versions (only version changes)
- aircrack (mentioned latest version of 1.5.1, which requires support for shtool, libstdc, and gmake (these should be added in termux-packages))
- arp-scan 1.9 -> 1.9.5
- cryptsetup 2.0.3 -> 2.0.6
- dnsmasq 2.79 -> 2.80
- ethtool 4.11 -> 4.19
- frida-server 12.2.14 -> 12.2.26 (updating this took a while lol) (and also bumped node from 8.12.0 -> 8.14.0)
- iw 4.9 -> 4.14
- libdevmapper 2.02.177 -> 2.03.00
- libfuse (mentioned 3.3.0)
- tshark 2.6.3 -> 2.6.5