### PR TITLE
Add support for GPG smartcards.

### DIFF
--- a/packages/libccid/build.sh
+++ b/packages/libccid/build.sh
@@ -1,0 +1,12 @@
+TERMUX_PKG_HOMEPAGE=https://ccid.apdu.fr/
+TERMUX_PKG_DESCRIPTION="A generic USB CCID (Chip/Smart Card Interface Devices) driver and ICCD (Integrated Circuit(s) Card Devices)."
+TERMUX_PKG_LICENSE="LGPL-2.1"
+TERMUX_PKG_VERSION=1.4.30
+TERMUX_PKG_REVISION=0
+TERMUX_PKG_SRCURL=https://ccid.apdu.fr/files/ccid-1.4.30.tar.bz2
+TERMUX_PKG_SHA256=ac17087be08880a0cdf99a8a2799a4ef004dc6ffa08b4d9b0ad995f39a53ff7c
+TERMUX_PKG_DEPENDS="libpcsclite, libusb, flex"
+
+termux_step_pre_configure() {
+	export LEXLIB=$TERMUX_PREFIX/lib/libfl.so
+}

--- a/packages/libpcsclite/build.sh
+++ b/packages/libpcsclite/build.sh
@@ -1,0 +1,21 @@
+TERMUX_PKG_HOMEPAGE=https://pcsclite.apdu.fr/
+TERMUX_PKG_DESCRIPTION="Middleware to access a smart card using SCard API (PC/SC)."
+TERMUX_PKG_LICENSE="BSD 3-Clause"
+TERMUX_PKG_VERSION=1.8.24
+TERMUX_PKG_REVISION=0
+TERMUX_PKG_SRCURL=https://pcsclite.apdu.fr/files/pcsc-lite-1.8.24.tar.bz2
+TERMUX_PKG_SHA256=b81864fa6a5ec776639c02ae89998955f7702a8d10e8b8f70023c5a599d97568
+TERMUX_PKG_DEPENDS="libusb"
+TERMUX_PKG_DEVPACKAGE_DEPENDS="python2"
+TERMUX_PKG_BUILD_DEPENDS="flex"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+--exec-prefix=$TERMUX_PREFIX
+--sbindir=$TERMUX_PREFIX/bin
+--enable-ipcdir=$TERMUX_PREFIX/var/run
+--disable-libsystemd
+--disable-libudev"
+TERMUX_PKG_INCLUDE_IN_DEVPACKAGE="bin/pcsc-spy share/man/man1/pcsc-spy.1.gz"
+
+termux_step_pre_configure() {
+	LDFLAGS+=" -llog"
+}

--- a/packages/libpcsclite/pcscd.subpackage.sh
+++ b/packages/libpcsclite/pcscd.subpackage.sh
@@ -1,0 +1,2 @@
+TERMUX_SUBPKG_DESCRIPTION="Middleware to access a smart card using SCard API (PC/SC). (daemon side)"
+TERMUX_SUBPKG_INCLUDE="bin/pcscd share/man/man5/reader.conf.5.gz share/man/man8/pcscd.8.gz"


### PR DESCRIPTION
The two packages will enable `gpg` to use smartcards (e.g. Yubikey) connected to an OTG cable. (with `pcscd` run as root)