### PR TITLE
Add termshark

### DIFF
--- a/packages/termshark/build.sh
+++ b/packages/termshark/build.sh
@@ -1,0 +1,24 @@
+TERMUX_PKG_HOMEPAGE=https://termshark.io
+TERMUX_PKG_DESCRIPTION="A terminal UI for tshark, inspired by Wireshark"
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_VERSION=1.0.0
+TERMUX_PKG_SHA256=669bba0e8dd7df54ade6321a5c7d2ec20563ffd777f7b3b0394a11f88da64698
+TERMUX_PKG_SRCURL=https://github.com/gcla/termshark/archive/v${TERMUX_PKG_VERSION}.tar.gz
+
+TERMUX_PKG_DEPENDS="tshark"
+
+termux_step_make() {
+	termux_setup_golang
+
+	export GOPATH=$TERMUX_PKG_BUILDDIR
+	export GO111MODULE=on
+
+	cd $TERMUX_PKG_BUILDDIR
+	go get -d -v github.com/gcla/termshark@v${TERMUX_PKG_VERSION}
+	go build -ldflags="-X github.com/gcla/termshark.Version=${TERMUX_PKG_VERSION}" github.com/gcla/termshark/cmd/termshark
+}
+
+termux_step_make_install() {
+	cd $TERMUX_PKG_BUILDDIR
+	install -Dm700 termshark $TERMUX_PREFIX/bin/termshark
+}


### PR DESCRIPTION
Termshark is a terminal UI for tshark. It's written in golang and as such
consists of one binary. This is a minimal termux build script to make
termshark available.

I originally made this PR at termux-packages -
https://github.com/termux/termux-packages/pull/3931 - but the recommendation
from that discussion was to submit against root packages instead. Termshark
needs tshark at runtime, and tshark could come from either
x11-repo:wireshark-gtk or root-repo:tshark.

More info on termshark is available at https://github.com/gcla/termshark.