### PR TITLE
libusb: update to v1.0.23-rc1

### DIFF
--- a/packages/libusb/build.sh
+++ b/packages/libusb/build.sh
@@ -1,9 +1,9 @@
 TERMUX_PKG_HOMEPAGE=https://libusb.info/
 TERMUX_PKG_DESCRIPTION="A C library that provides generic access to USB devices"
 TERMUX_PKG_LICENSE="LGPL-2.1"
-TERMUX_PKG_VERSION=1.0.22
+TERMUX_PKG_VERSION=1.0.23-rc1
 TERMUX_PKG_SRCURL=https://github.com/libusb/libusb/archive/v${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=3500f7b182750cd9ccf9be8b1df998f83df56a39ab264976bdb3307773e16f48
+TERMUX_PKG_SHA256=e8b42af53a54488286bf164266766c9ca7fb692773fe7b47ea0ccca4d6fbf4a0
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--disable-udev"
 
 termux_step_pre_configure() {


### PR DESCRIPTION
This adds the patches from https://github.com/libusb/libusb/pull/242, which should make it possible to use libusb on newer android versions if we add a UsbOpen function to termux-api

(I'm saying should as my initial tests on android-9 haven't worked so far). 