### PR TITLE
new package: openvpn

### DIFF
--- a/packages/openvpn/build.sh
+++ b/packages/openvpn/build.sh
@@ -1,0 +1,32 @@
+TERMUX_PKG_HOMEPAGE=https://openvpn.net
+TERMUX_PKG_DESCRIPTION="An easy-to-use, robust, and highly configurable VPN (Virtual Private Network)"
+TERMUX_PKG_LICENSE="GPL-2.0"
+TERMUX_PKG_VERSION=2.4.7
+TERMUX_PKG_SRCURL=https://swupdate.openvpn.net/community/releases/openvpn-${TERMUX_PKG_VERSION}.tar.xz
+TERMUX_PKG_SHA256=a42f53570f669eaf10af68e98d65b531015ff9e12be7a62d9269ea684652f648
+TERMUX_PKG_DEPENDS="liblz4, liblzo, net-tools, openssl"
+TERMUX_PKG_BUILD_IN_SRC=true
+
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+--disable-plugin-auth-pam
+--disable-systemd
+--disable-debug
+--enable-iproute2
+--enable-small
+--enable-x509-alt-username
+ac_cv_func_getpwnam=yes
+IFCONFIG=$TERMUX_PREFIX/bin/ifconfig
+ROUTE=$TERMUX_PREFIX/bin/route
+IPROUTE=$TERMUX_PREFIX/bin/ip
+NETSTAT=$TERMUX_PREFIX/bin/netstat
+"
+
+termux_step_pre_configure() {
+	export LIBS="-llog"
+}
+
+termux_step_post_make_install() {
+	# Examples.
+	install -d -m700 "$TERMUX_PREFIX/share/openvpn/examples"
+	cp "$TERMUX_PKG_SRCDIR"/sample/sample-config-files/* "$TERMUX_PREFIX/share/openvpn/examples"
+}

--- a/packages/openvpn/src-openvpn-console_builtin.c.patch
+++ b/packages/openvpn/src-openvpn-console_builtin.c.patch
@@ -1,0 +1,50 @@
+diff -uNr openvpn-2.4.7/src/openvpn/console_builtin.c openvpn-2.4.7.mod/src/openvpn/console_builtin.c
+--- openvpn-2.4.7/src/openvpn/console_builtin.c	2019-02-20 14:28:20.000000000 +0200
++++ openvpn-2.4.7.mod/src/openvpn/console_builtin.c	2019-09-18 14:32:21.891795281 +0300
+@@ -40,6 +40,8 @@
+ #include "buffer.h"
+ #include "misc.h"
+ 
++#include <unistd.h>
++
+ #ifdef _WIN32
+ 
+ #include "win32.h"
+@@ -138,8 +140,6 @@
+ #endif   /* _WIN32 */
+ 
+ 
+-#ifdef HAVE_GETPASS
+-
+ /**
+  * Open the current console TTY for read/write operations
+  *
+@@ -177,7 +177,6 @@
+     }
+ }
+ 
+-#endif   /* HAVE_GETPASS */
+ 
+ 
+ /**
+@@ -199,10 +198,6 @@
+     ASSERT(capacity > 0);
+     input[0] = '\0';
+ 
+-#if defined(_WIN32)
+-    return get_console_input_win32(prompt, echo, input, capacity);
+-#elif defined(HAVE_GETPASS)
+-
+     /* did we --daemon'ize before asking for passwords?
+      * (in which case neither stdin or stderr are connected to a tty and
+      * /dev/tty can not be open()ed anymore)
+@@ -247,9 +242,6 @@
+             ret = true;
+         }
+     }
+-#else  /* if defined(_WIN32) */
+-    msg(M_FATAL, "Sorry, but I can't get console input on this OS (%s)", prompt);
+-#endif /* if defined(_WIN32) */
+     return ret;
+ }
+ 

--- a/packages/openvpn/src-openvpn-options.c.patch
+++ b/packages/openvpn/src-openvpn-options.c.patch
@@ -1,0 +1,12 @@
+diff -uNr openvpn-2.4.7/src/openvpn/options.c openvpn-2.4.7.mod/src/openvpn/options.c
+--- openvpn-2.4.7/src/openvpn/options.c	2019-02-20 14:28:23.000000000 +0200
++++ openvpn-2.4.7.mod/src/openvpn/options.c	2019-09-18 14:41:05.337638310 +0300
+@@ -898,7 +898,7 @@
+     o->tmp_dir = getenv("TMPDIR");
+     if (!o->tmp_dir)
+     {
+-        o->tmp_dir = "/tmp";
++        o->tmp_dir = "@TERMUX_PREFIX@/tmp";
+     }
+ #endif /* _WIN32 */
+ #endif /* P2MP_SERVER */

--- a/packages/openvpn/src-openvpn-tun.c.patch
+++ b/packages/openvpn/src-openvpn-tun.c.patch
@@ -1,0 +1,11 @@
+--- ./src/openvpn/tun.c 2016-12-26 11:51:00.000000000 +0000
++++ ../tun.c    2016-12-28 04:11:52.786734486 +0000
+@@ -1939,7 +1939,7 @@
+         const char *node = dev_node;
+         if (!node)
+         {
+-            node = "/dev/net/tun";
++            node = "/dev/tun";
+         }
+ 
+         /*


### PR DESCRIPTION
Solution for https://github.com/termux/termux-root-packages/issues/123. I think it still nice to have this package, even if it usable only by *advanced* users.

It works, connects to server. But routing tables are not configured correctly and that results in traffic routed to the clearnet bypassing VPN.