### PR TITLE
[WIP] open-zwave 

### DIFF
--- a/packages/open-zwave/build.sh
+++ b/packages/open-zwave/build.sh
@@ -1,0 +1,7 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/OpenZWave/open-zwave
+TERMUX_PKG_DESCRIPTION="a C++ library to control Z-Wave Networks via a USB Z-Wave Controller. "
+TERMUX_PKG_LICENSE="LGPL-3.0"
+TERMUX_PKG_VERSION=1.6.1
+TERMUX_PKG_SRCURL=https://github.com/sviete/open-zwave/archive/v$TERMUX_PKG_VERSION.zip
+TERMUX_PKG_SHA256=ecf10aa7cd5dd51172e960c0fd3ea418a24ad39d3d5db026d6bfc3d8c08ef4a0
+TERMUX_PKG_BUILD_IN_SRC=true


### PR DESCRIPTION
Hi,
we were are able to compile open-zwave on Android device with this little change:
OpenZWave/open-zwave#2178

The steps in Termux on device are:

```
pkg install clang git
ln -s /system/lib/libc.so /data/data/com.termux/files/usr/lib/libresolv.so
/*libresolv is needed to compile open-zwave*/
git clone https://github.com/sviete/open-zwave.git
cd open-zwave
LIBS+=-latomic make
PREFIX=$PREFIX make install
```

After this all is ready, we can plug the USB Zwave stick to USB, the device is visible on:
/dev/ttyACM*

and we can use zwave, like below:
```
MinOZW /dev/ttyACM0
Starting MinOZW with OpenZWave Version 1.5.1
....
```

Unfortunately we are not able to add this as termux package, the full log is below:

```
./scripts/run-docker.sh ./build-package.sh -f -a arm termux-root-packages/packages/open-zwave/
Running container 'termux-package-builder' from image 'termux/package-builder'...
termux - building open-zwave for arch arm...
/home/builder/termux-packages/.termux-build/open-zwave/src/cpp/build/support.mk:82: Missing Either Git Binary, Not a Source Checkout or doesn't have a vers.cpp
make[1]: warning: -j8 forced in submake: resetting jobserver mode.
make[1]: Entering directory '/home/builder/termux-packages/.termux-build/open-zwave/src/cpp/build'
/home/builder/termux-packages/.termux-build/open-zwave/src/cpp/build/support.mk:82: Missing Either Git Binary, Not a Source Checkout or doesn't have a vers.cpp
Building OpenZWave Version  - 1.6.0
Building tinyxml/tinystr.cpp
Building tinyxml/tinyxmlerror.cpp
Building tinyxml/tinyxml.cpp
Building tinyxml/tinyxmlparser.cpp
Building aes/aeskey.c
g++: error: unrecognized command line option ‘-mfpu=neon’
g++: error: unrecognized command line option ‘-mfpu=neon’
Building aes/aescrypt.c
Building aes/aestab.c
g++: error: unrecognized command line option ‘-mfpu=neon’
g++: error: unrecognized command line option ‘-mfpu=neon’
g++: error: unrecognized command line option ‘-mfloat-abi=softfp’
g++: error: unrecognized command line option ‘-mfloat-abi=softfp’
g++: error: unrecognized command line option ‘-mthumb’
g++: error: unrecognized command line option ‘-mthumb’
make[1]: *** [/home/builder/termux-packages/.termux-build/open-zwave/src/cpp/build/support.mk:187: /home/builder/termux-packages/.termux-build/open-zwave/src/.lib/tinystr.o] Error 1
make[1]: *** Waiting for unfinished jobs....
gcc: error: unrecognized command line option ‘-mfpu=neon’
gcc: error: unrecognized command line option ‘-mfpu=neon’
gcc: error: unrecognized command line option ‘-mfpu=neon’
g++: error: unrecognized command line option ‘-mfloat-abi=softfp’
make[1]: *** [/home/builder/termux-packages/.termux-build/open-zwave/src/cpp/build/support.mk:187: /home/builder/termux-packages/.termux-build/open-zwave/src/.lib/tinyxmlerror.o] Error 1
g++: error: unrecognized command line option ‘-mfloat-abi=softfp’
g++: error: unrecognized command line option ‘-mthumb’
g++: error: unrecognized command line option ‘-mthumb’
make[1]: *** [/home/builder/termux-packages/.termux-build/open-zwave/src/cpp/build/support.mk:187: /home/builder/termux-packages/.termux-build/open-zwave/src/.lib/tinyxml.o] Error 1
make[1]: *** [/home/builder/termux-packages/.termux-build/open-zwave/src/cpp/build/support.mk:187: /home/builder/termux-packages/.termux-build/open-zwave/src/.lib/tinyxmlparser.o] Error 1
gcc: error: unrecognized command line option ‘-mfloat-abi=softfp’
gcc: error: unrecognized command line option ‘-mfloat-abi=softfp’
gcc: error: unrecognized command line option ‘-mfloat-abi=softfp’
gcc: error: unrecognized command line option ‘-mthumb’
gcc: error: unrecognized command line option ‘-mthumb’
make[1]: *** [/home/builder/termux-packages/.termux-build/open-zwave/src/cpp/build/support.mk:198: /home/builder/termux-packages/.termux-build/open-zwave/src/.lib/aestab.o] Error 1
gcc: error: unrecognized command line option ‘-mthumb’
make[1]: *** [/home/builder/termux-packages/.termux-build/open-zwave/src/cpp/build/support.mk:198: /home/builder/termux-packages/.termux-build/open-zwave/src/.lib/aeskey.o] Error 1
make[1]: *** [/home/builder/termux-packages/.termux-build/open-zwave/src/cpp/build/support.mk:198: /home/builder/termux-packages/.termux-build/open-zwave/src/.lib/aescrypt.o] Error 1
make[1]: Leaving directory '/home/builder/termux-packages/.termux-build/open-zwave/src/cpp/build'
make: *** [Makefile:23: all] Error 2
```

any idea how to fix this? 

