### PR TITLE
frida: update to 12.11.18

### DIFF
--- a/packages/frida-server/Makefile.linux.mk.patch
+++ b/packages/frida-server/Makefile.linux.mk.patch
@@ -33,17 +33,6 @@
  
  define make-python-rule
  build/$2-%/frida-$$(PYTHON_NAME)/.frida-stamp: build/.frida-python-submodule-stamp build/$1-%/lib/pkgconfig/frida-core-1.0.pc
-@@ -336,8 +348,8 @@
- 			--cross-file build/$1-$$*.txt \
- 			--prefix $$(FRIDA)/build/$1-$$* \
- 			--libdir $$(FRIDA)/build/$1-$$*/lib \
--			-Dpython=$$(PYTHON) \
--			-Dpython_incdir=$$(PYTHON_INCDIR) \
-+			-Dpython=/usr/bin/python3.8 \
-+			-Dpython_incdir=@TERMUX_PREFIX@/include/python3.8 \
- 			frida-python $$$$builddir || exit 1; \
- 	fi; \
- 	$$(NINJA) -C $$$$builddir install || exit 1
 @@ -366,13 +378,32 @@
  	export PYTHONPATH="$(shell pwd)/build/frida_thin-linux-arm64/lib/$(PYTHON_NAME)/site-packages" \
  		&& cd frida-python \

--- a/packages/frida-server/build.sh
+++ b/packages/frida-server/build.sh
@@ -4,10 +4,9 @@ TERMUX_PKG_LICENSE="wxWindows"
 TERMUX_PKG_MAINTAINER="Henrik Grimler @Grimler91"
 _MAJOR_VERSION=12
 _MINOR_VERSION=11
-_MICRO_VERSION=14
+_MICRO_VERSION=18
 TERMUX_PKG_VERSION=${_MAJOR_VERSION}.${_MINOR_VERSION}.${_MICRO_VERSION}
 TERMUX_PKG_GIT_BRANCH=$TERMUX_PKG_VERSION
-TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/frida/frida.git
 TERMUX_PKG_DEPENDS="libiconv, python"
 TERMUX_PKG_BUILD_DEPENDS="openssl"
@@ -19,6 +18,9 @@ TERMUX_PKG_CONFFILES="var/service/frida-server/run var/service/frida-server/down
 termux_step_pre_configure () {
 	_PYTHON_VERSION=$(source $TERMUX_SCRIPTDIR/packages/python/build.sh; echo $_MAJOR_VERSION)
 	export TERMUX_PKG_EXTRA_MAKE_ARGS+=" PYTHON=/usr/bin/python${_PYTHON_VERSION}"
+	sed -e "s%@TERMUX_PREFIX@%$TERMUX_PREFIX%g" \
+		-e "s%@PYTHON_VERSION@%$_PYTHON_VERSION%g" \
+		$TERMUX_PKG_BUILDER_DIR/frida-python-version.diff | patch -Np1
 }
 
 termux_step_host_build () {

--- a/packages/frida-server/frida-python-src-meson.build.patch
+++ b/packages/frida-server/frida-python-src-meson.build.patch
@@ -1,11 +1,5 @@
 --- ../frida-python-src-meson.build.orig	2020-03-25 07:54:47.948054199 +0100
 +++ ./frida-python/src/meson.build	2020-03-25 08:44:34.189059770 +0100
-@@ -1,4 +1,4 @@
--extra_link_args = []
-+extra_link_args = ['-L@TERMUX_PREFIX@/lib', '-lpython3.8']
- if host_os_family == 'darwin'
-   extra_link_args += ['-Wl,-exported_symbol,_' + python_plugin_export_name]
- elif host_os_family != 'windows'
 @@ -9,8 +9,8 @@
    name_prefix: '',
    name_suffix: 'so',

--- a/packages/frida-server/frida-python-version.diff
+++ b/packages/frida-server/frida-python-version.diff
@@ -1,0 +1,21 @@
+--- ../frida-python-src-meson.build.orig	2020-03-25 07:54:47.948054199 +0100
++++ ./frida-python/src/meson.build	2020-03-25 08:44:34.189059770 +0100
+@@ -1,4 +1,4 @@
+-extra_link_args = []
++extra_link_args = ['-L@TERMUX_PREFIX@/lib', '-lpython@PYTHON_VERSION@']
+ if host_os_family == 'darwin'
+   extra_link_args += ['-Wl,-exported_symbol,_' + python_plugin_export_name]
+ elif host_os_family != 'windows'
+--- ./Makefile.linux.mk.orig	2020-07-22 19:15:43.163995037 +0000
++++ ./Makefile.linux.mk	2020-07-22 19:19:19.060924976 +0000
+@@ -336,8 +348,8 @@
+ 			--cross-file build/$1-$$*.txt \
+ 			--prefix $$(FRIDA)/build/$1-$$* \
+ 			--libdir $$(FRIDA)/build/$1-$$*/lib \
+-			-Dpython=$$(PYTHON) \
+-			-Dpython_incdir=$$(PYTHON_INCDIR) \
++			-Dpython=/usr/bin/python@PYTHON_VERSION@ \
++			-Dpython_incdir=@TERMUX_PREFIX@/include/python@PYTHON_VERSION@ \
+ 			frida-python $$$$builddir || exit 1; \
+ 	fi; \
+ 	$$(NINJA) -C $$$$builddir install || exit 1


### PR DESCRIPTION
Building with python3.9 will not work until it is available in the docker image (ubuntu 20.04).