### PR TITLE
Enable squashfs package after some successful tests

### DIFF
--- a/packages/squashfuse/Makefile.am.patch
+++ b/packages/squashfuse/Makefile.am.patch
@@ -1,0 +1,18 @@
+diff --git a/squashfuse-0.1.103/Makefile.am b/Makefile.am
+index 1507525..8fbc17c 100644
+--- a/squashfuse-0.1.103/Makefile.am
++++ b/Makefile.am
+@@ -59,11 +59,11 @@ endif
+ 
+ if SQ_WANT_DEMO
+ # Sample program squashfuse_ls
+-noinst_PROGRAMS += squashfuse_ls
++bin_PROGRAMS += squashfuse_ls
+ squashfuse_ls_SOURCES = ls.c
+ squashfuse_ls_LDADD = libsquashfuse.la $(COMPRESSION_LIBS)
+ # Sample program squashfuse_extract
+-noinst_PROGRAMS += squashfuse_extract
++bin_PROGRAMS += squashfuse_extract
+ squashfuse_extract_CPPFLAGS = $(FUSE_CPPFLAGS)
+ squashfuse_extract_SOURCES = extract.c
+ squashfuse_extract_LDADD = libsquashfuse.la libfuseprivate.la $(COMPRESSION_LIBS) \

--- a/packages/squashfuse/build.sh
+++ b/packages/squashfuse/build.sh
@@ -2,14 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://github.com/vasi/squashfuse
 TERMUX_PKG_DESCRIPTION="FUSE filesystem to mount squashfs archives"
 TERMUX_PKG_LICENSE="BSD 2-Clause"
 TERMUX_PKG_VERSION=0.1.103
-TERMUX_PKG_REVISION=1
 TERMUX_PKG_SHA256=bba530fe435d8f9195a32c295147677c58b060e2c63d2d4204ed8a6c9621d0dd
 TERMUX_PKG_SRCURL=https://github.com/vasi/squashfuse/archive/${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_DEPENDS="libfuse2, zstd, liblz4, liblzo"
-
-TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
---prefix=$TERMUX_PREFIX
-"
 
 termux_step_pre_configure () {
 	./autogen.sh

--- a/packages/squashfuse/build.sh
+++ b/packages/squashfuse/build.sh
@@ -2,11 +2,15 @@ TERMUX_PKG_HOMEPAGE=https://github.com/vasi/squashfuse
 TERMUX_PKG_DESCRIPTION="FUSE filesystem to mount squashfs archives"
 TERMUX_PKG_LICENSE="BSD 2-Clause"
 TERMUX_PKG_VERSION=0.1.103
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SHA256=bba530fe435d8f9195a32c295147677c58b060e2c63d2d4204ed8a6c9621d0dd
 TERMUX_PKG_SRCURL=https://github.com/vasi/squashfuse/archive/${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_DEPENDS="libfuse"
+TERMUX_PKG_DEPENDS="libfuse2, zstd, liblz4, liblzo"
+
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+--prefix=$TERMUX_PREFIX
+"
 
 termux_step_pre_configure () {
-	aclocal --install
-	autoreconf -vfi
+	./autogen.sh
 }


### PR DESCRIPTION
@Grimler91 I don't really understand how this build.sh script works, and to be honest I didn't test it. Verify closely if things are correct.

Here are some questions I have:

1. Do I need to specify `--prefix` flag for configure args? From what I checked no other package uses it.
2. Do I need the `TERMUX_PKG_REVISION`? Only a few packages use it.
3. Do I need to use a release tarball or can I compile a package directly from the last commit of its github page?
4. Does the build script runs `make install` automatically?