### PR TITLE
Upgrade the official termshark termux package to v2.3.0

### DIFF
--- a/packages/termshark/build.sh
+++ b/packages/termshark/build.sh
@@ -2,9 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://termshark.io
 TERMUX_PKG_DESCRIPTION="A terminal UI for tshark, inspired by Wireshark"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION=2.2.0
+TERMUX_PKG_VERSION=2.3.0
 TERMUX_PKG_REVISION=1
-TERMUX_PKG_SHA256=deefdb0b65e5d5b97c305cf280770724542f8dd122502f616e394c62c91db0c4
+TERMUX_PKG_SHA256=8e2a22534773b1ab0ce4327e929bbbe413d3695bab2d55c985d1f61961698610
 TERMUX_PKG_SRCURL=https://github.com/gcla/termshark/archive/v${TERMUX_PKG_VERSION}.tar.gz
 
 TERMUX_PKG_DEPENDS="tshark"
@@ -16,7 +16,10 @@ termux_step_make() {
 	export GO111MODULE=on
 
 	cd $TERMUX_PKG_SRCDIR
-	go install github.com/gcla/termshark/v2/cmd/termshark
+	git clone https://github.com/gcla/termshark
+	cd termshark
+	git checkout v2.3.0
+	go install ./...
 }
 
 termux_step_make_install() {

--- a/packages/termshark/build.sh
+++ b/packages/termshark/build.sh
@@ -3,10 +3,7 @@ TERMUX_PKG_DESCRIPTION="A terminal UI for tshark, inspired by Wireshark"
 TERMUX_PKG_LICENSE="MIT"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=2.3.0
-TERMUX_PKG_REVISION=1
-TERMUX_PKG_SHA256=8e2a22534773b1ab0ce4327e929bbbe413d3695bab2d55c985d1f61961698610
-TERMUX_PKG_SRCURL=https://github.com/gcla/termshark/archive/v${TERMUX_PKG_VERSION}.tar.gz
-
+TERMUX_PKG_SRCURL=https://github.com/gcla/termshark.git
 TERMUX_PKG_DEPENDS="tshark"
 
 termux_step_make() {
@@ -16,13 +13,9 @@ termux_step_make() {
 	export GO111MODULE=on
 
 	cd $TERMUX_PKG_SRCDIR
-	git clone https://github.com/gcla/termshark
-	cd termshark
-	git checkout v2.3.0
 	go install ./...
 }
 
 termux_step_make_install() {
-	cd $TERMUX_PKG_BUILDDIR
 	install -Dm700 bin/android_${GOARCH}/termshark $TERMUX_PREFIX/bin/termshark
 }


### PR DESCRIPTION
As of Go 1.17, termshark can't be installed in a single go get/go install command because termshark uses replace directives in its go.mod
```
$ go install github.com/gcla/termshark/v2/cmd/termshark@latest
go install: github.com/gcla/termshark/v2/cmd/termshark@latest (in github.com/gcla/termshark/v2@v2.3.0):
        The go.mod file for the module providing named packages contains one or
        more replace directives. It must not contain directives that would cause
        it to be interpreted differently than if it were the main module.
```
This is discussed here: https://github.com/golang/go/issues/40276

Longer-term, I need to remove these directives, or wait for a Go release that makes it possible to use them with go install. Even though termux may not yet be using Go 1.17, I decided to git-clone and build inside the source directory instead.