### PR TITLE
libnfnetlink] new library required for libnetfilter_queue

### DIFF
--- a/packages/libnfnetlink/build.sh
+++ b/packages/libnfnetlink/build.sh
@@ -1,0 +1,16 @@
+TERMUX_PKG_HOMEPAGE=https://www.netfilter.org/projects/libnfnetlink/index.html
+TERMUX_PKG_DESCRIPTION="libnfnetlink is the low-level library for netfilter related kernel/userspace communication."
+TERMUX_PKG_LICENSE="GPL"
+TERMUX_PKG_LICENSE_FILE="COPYING"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION=1.0.1
+TERMUX_PKG_REVISION=1
+TERMUX_PKG_SRCURL=http://ftp.netfilter.org/pub/libnfnetlink/libnfnetlink-${TERMUX_PKG_VERSION}.tar.bz2
+TERMUX_PKG_SHA256=f270e19de9127642d2a11589ef2ec97ef90a649a74f56cf9a96306b04817b51a
+# TERMUX_PKG_DEPENDS=""
+# TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--disable-static"
+
+#termux_step_pre_configure() {
+#	./autogen.sh
+#}
+

--- a/packages/libnfnetlink/build.sh
+++ b/packages/libnfnetlink/build.sh
@@ -1,16 +1,9 @@
 TERMUX_PKG_HOMEPAGE=https://www.netfilter.org/projects/libnfnetlink/index.html
 TERMUX_PKG_DESCRIPTION="libnfnetlink is the low-level library for netfilter related kernel/userspace communication."
-TERMUX_PKG_LICENSE="GPL"
+TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_LICENSE_FILE="COPYING"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=1.0.1
 TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=http://ftp.netfilter.org/pub/libnfnetlink/libnfnetlink-${TERMUX_PKG_VERSION}.tar.bz2
 TERMUX_PKG_SHA256=f270e19de9127642d2a11589ef2ec97ef90a649a74f56cf9a96306b04817b51a
-# TERMUX_PKG_DEPENDS=""
-# TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--disable-static"
-
-#termux_step_pre_configure() {
-#	./autogen.sh
-#}
-


### PR DESCRIPTION
This library is required for build libnetfilter_queue and libnetfilter_queue is required for build bettercap 2.32.0
