### PR TITLE
[libnetfilter_queue] this library is required for build bettercap 2.32.0

### DIFF
--- a/packages/libnetfilter_queue/build.sh
+++ b/packages/libnetfilter_queue/build.sh
@@ -1,0 +1,10 @@
+TERMUX_PKG_HOMEPAGE=https://www.netfilter.org/projects/libnetfilter_queue/index.html
+TERMUX_PKG_DESCRIPTION="libnetfilter_queue is a userspace library providing an API to packets that have been queued by the kernel packet filter."
+TERMUX_PKG_LICENSE="GPL-2.0"
+TERMUX_PKG_LICENSE_FILE="COPYING"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION=1.0.5
+TERMUX_PKG_REVISION=1
+TERMUX_PKG_SRCURL=http://ftp.netfilter.org/pub/libnetfilter_queue/libnetfilter_queue-${TERMUX_PKG_VERSION}.tar.bz2
+TERMUX_PKG_SHA256=f9ff3c11305d6e03d81405957bdc11aea18e0d315c3e3f48da53a24ba251b9f5
+TERMUX_PKG_DEPENDS="libnfnetlink"

--- a/packages/libnetfilter_queue/build.sh
+++ b/packages/libnetfilter_queue/build.sh
@@ -1,10 +1,8 @@
 TERMUX_PKG_HOMEPAGE=https://www.netfilter.org/projects/libnetfilter_queue/index.html
 TERMUX_PKG_DESCRIPTION="libnetfilter_queue is a userspace library providing an API to packets that have been queued by the kernel packet filter."
 TERMUX_PKG_LICENSE="GPL-2.0"
-TERMUX_PKG_LICENSE_FILE="COPYING"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=1.0.5
-TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=http://ftp.netfilter.org/pub/libnetfilter_queue/libnetfilter_queue-${TERMUX_PKG_VERSION}.tar.bz2
 TERMUX_PKG_SHA256=f9ff3c11305d6e03d81405957bdc11aea18e0d315c3e3f48da53a24ba251b9f5
-TERMUX_PKG_DEPENDS="libnfnetlink"
+TERMUX_PKG_DEPENDS="libnfnetlink, libmnl"

--- a/packages/libnetfilter_queue/fix-redefinition.patch
+++ b/packages/libnetfilter_queue/fix-redefinition.patch
@@ -1,0 +1,17 @@
+diff --git a/src/extra/tcp.c b/src/extra/tcp.c
+index 933c6ee..e69d629 100644
+--- a/src/extra/tcp.c
++++ b/src/extra/tcp.c
+@@ -139,10 +139,12 @@ void nfq_tcp_compute_checksum_ipv6(struct tcphdr *tcph, struct ip6_hdr *ip6h)
+  *  (union is compatible to any of its members)
+  *  This means this part of the code is -fstrict-aliasing safe now.
+  */
++/*
+ union tcp_word_hdr {
+ 	struct tcphdr hdr;
+ 	uint32_t  words[5];
+ };
++*/
+ 
+ #define tcp_flag_word(tp) ( ((union tcp_word_hdr *)(tp))->words[3])
+ 


### PR DESCRIPTION
require changes of these include files in ndk_sysrooty:
/data/data/com.termux/files/usr/include/netinet/if_ether.h
/data/data/com.termux/files/usr/include/netinet/ip.h
/data/data/com.termux/files/usr/include/linux/netfilter/nfnetlink.h
