### PR TITLE
[libnetfilter-queue] fix missing define on ipv4.c

### DIFF
--- a/packages/libnetfilter-queue/build.sh
+++ b/packages/libnetfilter-queue/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="libnetfilter_queue is a userspace library providing an A
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=1.0.5
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=http://ftp.netfilter.org/pub/libnetfilter_queue/libnetfilter_queue-${TERMUX_PKG_VERSION}.tar.bz2
 TERMUX_PKG_SHA256=f9ff3c11305d6e03d81405957bdc11aea18e0d315c3e3f48da53a24ba251b9f5
 TERMUX_PKG_DEPENDS="libnfnetlink, libmnl"

--- a/packages/libnetfilter-queue/fix-missing-define-ipv4.patch
+++ b/packages/libnetfilter-queue/fix-missing-define-ipv4.patch
@@ -1,0 +1,22 @@
+diff --git a/src/extra/ipv4.c b/src/extra/ipv4.c
+index 797bab1..37eae7b 100644
+--- a/src/extra/ipv4.c
++++ b/src/extra/ipv4.c
+@@ -20,6 +20,17 @@
+ 
+ #include "internal.h"
+ 
++// on debian linux system netinet/ip.h has this define
++// on ndk-sysroot there are only in linux/ip.h but include it
++// introduce an issue on redifinition
++#define IPTOS_CLASS_MASK	0xe0
++#define IPTOS_CLASS(class)	((class) & IPTOS_CLASS_MASK)
++
++#define IPTOS_PREC(tos)		IPTOS_CLASS(tos)
++
++#define	IPTOS_TOS_MASK		0x1E
++#define	IPTOS_TOS(tos)		((tos) & IPTOS_TOS_MASK)
++
+ /**
+  * \defgroup ipv4 IPv4 helper functions
+  * @{


### PR DESCRIPTION
This PR fix the missing define IPTOS_TOS
In a debian linux system both netinet/ip.h and linux/ip.h has this define, on ndk-sysroot only linux/ip.h but I can't include it because there is an issue on redifinition
The easy way is include it in source file ipv4.c
I inserted also the define for IPTOS_PREC, so no warning while the compilation, only a macro redifinition which is not a error
