### PR TITLE
Added package cyanrip to rips cds via otg connected cd/dvd player

### DIFF
--- a/packages/cyanrip/build.sh
+++ b/packages/cyanrip/build.sh
@@ -1,7 +1,7 @@
 TERMUX_PKG_HOMEPAGE=https://github.com/cyanreg/cyanrip
-TERMUX_PKG_DESCRIPTION="Fully featured CD ripping program able to take out most of the tedium. Fully accurate, has advanced features most rippers don't, yet has no bloat and is cross-platform."
+TERMUX_PKG_DESCRIPTION="Fully featured CD ripping program."
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_LICENSE="LGPL- 2.1"
+TERMUX_PKG_LICENSE="LGPL-2.1"
 TERMUX_PKG_VERSION=0.7.0
 TERMUX_PKG_SRCURL=https://github.com/cyanreg/cyanrip/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=67318dee2a21ed17b98b406dfd2c86568c649fc4596c8fb22f8a767b7a7406d0

--- a/packages/cyanrip/build.sh
+++ b/packages/cyanrip/build.sh
@@ -1,0 +1,8 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/cyanreg/cyanrip
+TERMUX_PKG_DESCRIPTION="Fully featured CD ripping program able to take out most of the tedium. Fully accurate, has advanced features most rippers don't, yet has no bloat and is cross-platform."
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_LICENSE="LGPL- 2.1"
+TERMUX_PKG_VERSION=0.7.0
+TERMUX_PKG_SRCURL=https://github.com/cyanreg/cyanrip/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=67318dee2a21ed17b98b406dfd2c86568c649fc4596c8fb22f8a767b7a7406d0
+TERMUX_PKG_DEPENDS="libcdio, ffmpeg, libmusicbrainz"

--- a/packages/libcdio-paranoia/build.sh
+++ b/packages/libcdio-paranoia/build.sh
@@ -1,20 +1,11 @@
 TERMUX_PKG_HOMEPAGE=https://www.gnu.org/software/libcdio
 TERMUX_PKG_DESCRIPTION="This is a port of xiph.org's cdda paranoia to use libcdio for CDROM access."
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_LICENSE="GNU Public License 3.0"
+TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_VERSION=10.2+2.0.1
 TERMUX_PKG_SRCURL=https://ftp.gnu.org/gnu/libcdio/libcdio-paranoia-${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=28d7d00e4a83d0221acda0fd2eb3e3240bf094db4c00a85998922201939fa952
-TERMUX_PKG_DEPENDS="libcdio"
-TERMUX_INSTALL_DEPS=true
-TERMUX_PKG_BUILD_IN_SRC=true
-termux_step_configure() {
-	${TERMUX_PKG_SRCDIR}/configure --prefix=${PREFIX} LDFLAGS=" -landroid-glob"
+TERMUX_PKG_DEPENDS="libcdio, libandroid-glob"
+termux_step_pre_configure() {
+	LDFLAGS=" -landroid-glob"
 }
-termux_step_make(){
-	cd ${TERMUX_PKG_SRCDIR} && make -j8
-}
-termux_step_make_install() {
-	cd ${TERMUX_PKG_SRCDIR} && make install
-}
-

--- a/packages/libcdio-paranoia/build.sh
+++ b/packages/libcdio-paranoia/build.sh
@@ -1,0 +1,20 @@
+TERMUX_PKG_HOMEPAGE=https://www.gnu.org/software/libcdio
+TERMUX_PKG_DESCRIPTION="This is a port of xiph.org's cdda paranoia to use libcdio for CDROM access."
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_LICENSE="GNU Public License 3.0"
+TERMUX_PKG_VERSION=10.2+2.0.1
+TERMUX_PKG_SRCURL=https://ftp.gnu.org/gnu/libcdio/libcdio-paranoia-${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=28d7d00e4a83d0221acda0fd2eb3e3240bf094db4c00a85998922201939fa952
+TERMUX_PKG_DEPENDS="libcdio"
+TERMUX_INSTALL_DEPS=true
+TERMUX_PKG_BUILD_IN_SRC=true
+termux_step_configure() {
+	${TERMUX_PKG_SRCDIR}/configure --prefix=${PREFIX} LDFLAGS=" -landroid-glob"
+}
+termux_step_make(){
+	cd ${TERMUX_PKG_SRCDIR} && make -j8
+}
+termux_step_make_install() {
+	cd ${TERMUX_PKG_SRCDIR} && make install
+}
+

--- a/packages/libcdio/build.sh
+++ b/packages/libcdio/build.sh
@@ -1,0 +1,23 @@
+TERMUX_PKG_HOMEPAGE=https://www.gnu.org/software/libcdio
+TERMUX_PKG_DESCRIPTION="The GNU Compact Disc Input and Control library (libcdio) contains a library for CD-ROM and CD image access. Applications wishing to be oblivious of the OS- and device-dependent properties of a CD-ROM or of the specific details of various CD-image formats may benefit from using this library."
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_LICENSE="GNU Public License 3.0"
+TERMUX_PKG_VERSION=2.1.0
+TERMUX_PKG_SRCURL=https://ftp.gnu.org/gnu/libcdio/libcdio-${TERMUX_PKG_VERSION}.tar.bz2
+TERMUX_PKG_SHA256=8550e9589dbd594bfac93b81ecf129b1dc9d0d51e90f9696f1b2f9b2af32712b
+TERMUX_INSTALL_DEPS=true
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_SUGGESTS="libcdio-paranoia, swig"
+termux_step_configure() {
+	${TERMUX_PKG_SRCDIR}/configure --prefix=${PREFIX} LDFLAGS=" -landroid-glob"
+}
+termux_step_make(){
+	cd ${TERMUX_PKG_SRCDIR} && make -j8
+}
+termux_step_make_install() {
+	cd ${TERMUX_PKG_SRCDIR} && make install
+}
+termux_step_post_make_install() {
+	echo 'To install python bindings use  pip3 install pycdio (Requires swig to be installed)'
+	echo 'To install perl bindings use  cpan Device::Cdio'
+}

--- a/packages/libcdio/build.sh
+++ b/packages/libcdio/build.sh
@@ -1,23 +1,18 @@
 TERMUX_PKG_HOMEPAGE=https://www.gnu.org/software/libcdio
-TERMUX_PKG_DESCRIPTION="The GNU Compact Disc Input and Control library (libcdio) contains a library for CD-ROM and CD image access. Applications wishing to be oblivious of the OS- and device-dependent properties of a CD-ROM or of the specific details of various CD-image formats may benefit from using this library."
+TERMUX_PKG_DESCRIPTION="Compact Disc Input and Control library"
 TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_LICENSE="GNU Public License 3.0"
+TERMUX_PKG_LICENSE="GPL-3.0"
 TERMUX_PKG_VERSION=2.1.0
 TERMUX_PKG_SRCURL=https://ftp.gnu.org/gnu/libcdio/libcdio-${TERMUX_PKG_VERSION}.tar.bz2
 TERMUX_PKG_SHA256=8550e9589dbd594bfac93b81ecf129b1dc9d0d51e90f9696f1b2f9b2af32712b
 TERMUX_INSTALL_DEPS=true
-TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_DEPENDS="libandroid-glob"
 TERMUX_PKG_SUGGESTS="libcdio-paranoia, swig"
-termux_step_configure() {
-	${TERMUX_PKG_SRCDIR}/configure --prefix=${PREFIX} LDFLAGS=" -landroid-glob"
+termux_step_pre_configure() {
+	LDFLAGS=" -landroid-glob"
 }
-termux_step_make(){
-	cd ${TERMUX_PKG_SRCDIR} && make -j8
-}
-termux_step_make_install() {
-	cd ${TERMUX_PKG_SRCDIR} && make install
-}
-termux_step_post_make_install() {
-	echo 'To install python bindings use  pip3 install pycdio (Requires swig to be installed)'
-	echo 'To install perl bindings use  cpan Device::Cdio'
+termux_step_create_debscripts() {
+	echo "#!$TERMUX_PREFIX/bin/sh" >> postinst
+	echo "echo To install python bindings use pip3 install pycdio (Requires swig to be installed)" >> postinst
+	echo "echo To install perl bindings use cpan Device::Cdio" >> postinst
 }


### PR DESCRIPTION
Added package cyanrip to rips cds via otg connected cd/dvd player and its dependencies libcdio, libcdio-paranoia. 
It also depends on  libmusicbrianz  whose PR is made on termux main repo.