### PR TITLE
lxc: fix link to source code

### DIFF
--- a/packages/lxc/build.sh
+++ b/packages/lxc/build.sh
@@ -6,7 +6,7 @@ TERMUX_PKG_MAINTAINER="Leonid Pliushch <leonid.pliushch@gmail.com>"
 # Do not update it unless you tested it on your device.
 TERMUX_PKG_VERSION=1:3.1.0
 TERMUX_PKG_REVISION=2
-TERMUX_PKG_SRCURL=https://linuxcontainers.org/downloads/lxc-${TERMUX_PKG_VERSION:2}.tar.gz
+TERMUX_PKG_SRCURL=https://linuxcontainers.org/downloads/lxc/lxc-${TERMUX_PKG_VERSION:2}.tar.gz
 TERMUX_PKG_SHA256=4d8772c25baeaea2c37a954902b88c05d1454c91c887cb6a0997258cfac3fdc5
 TERMUX_PKG_DEPENDS="gnupg, libcap, libseccomp, rsync, wget"
 TERMUX_PKG_BREAKS="lxc-dev"


### PR DESCRIPTION
The problem was seen in action: https://github.com/Maxython/termux-root-packages-pacman/actions/runs/1752168799