### PR TITLE
hwinfo: Fix build failure "No rule to make target"

### DIFF
--- a/packages/docker/build.sh
+++ b/packages/docker/build.sh
@@ -5,6 +5,7 @@ TERMUX_PKG_MAINTAINER="@termux"
 # remember to update DOCKER_GITCOMMIT inside termux_step_make()
 # bellow when upgrading to a new version
 TERMUX_PKG_VERSION=20.10.2
+TERMUX_PKG_REVISION=1
 LIBNETWORK_COMMIT=448016ef11309bd67541dcf4d72f1f5b7de94862
 TERMUX_PKG_SRCURL=(https://github.com/moby/moby/archive/v${TERMUX_PKG_VERSION}.tar.gz
                    https://github.com/docker/cli/archive/v${TERMUX_PKG_VERSION}.tar.gz
@@ -48,6 +49,7 @@ termux_step_get_source() {
 termux_step_make() {
 	# setup go build environment
 	termux_setup_golang
+	export GO111MODULE=auto
 
 	# BUILD DOCKERD DAEMON
 	echo -n "Building dockerd daemon..."

--- a/packages/hping3/build.sh
+++ b/packages/hping3/build.sh
@@ -4,13 +4,14 @@ TERMUX_PKG_DESCRIPTION="hping is a command-line oriented TCP/IP packet assembler
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=3.0.0
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_REVISION=2
 TERMUX_PKG_SRCURL=http://www.hping.org/hping3-20051105.tar.gz
 TERMUX_PKG_SHA256=f5a671a62a11dc8114fa98eade19542ed1c3aa3c832b0e572ca0eb1a5a4faee8
 TERMUX_PKG_DEPENDS="libandroid-shmem, libpcap, tcl"
 TERMUX_PKG_BUILD_IN_SRC=true
 
 termux_step_post_configure () {
+	LDFLAGS+=" -Wl,-z,muldefs"
 	export LDFLAGS+=" -landroid-shmem"
 	mkdir -p ${TERMUX_PREFIX}/share/man/man8
 }

--- a/packages/hwinfo/build.sh
+++ b/packages/hwinfo/build.sh
@@ -23,4 +23,5 @@ termux_step_configure() {
 	echo 'touch changelog' > git2log
 	LDFLAGS+=" -landroid-shmem"
         export HWINFO_VERSION="$TERMUX_PKG_VERSION"
+        export DESTDIR="$TERMUX_PREFIX"
 }

--- a/packages/hwinfo/build.sh
+++ b/packages/hwinfo/build.sh
@@ -3,12 +3,21 @@ TERMUX_PKG_DESCRIPTION="Hardware detection tool from openSUSE"
 TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux"
 TERMUX_PKG_VERSION=21.74
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/openSUSE/hwinfo/archive/$TERMUX_PKG_VERSION.tar.gz
 TERMUX_PKG_SHA256=e826865af657c4966c37c8e915499dc148ff6df4879d3d86f71885defee8335c
 TERMUX_PKG_DEPENDS="libandroid-shmem, libuuid, libx86emu"
 TERMUX_PKG_BREAKS="hwinfo-dev"
 TERMUX_PKG_REPLACES="hwinfo-dev"
 TERMUX_PKG_BUILD_IN_SRC=true
+
+termux_step_pre_configure() {
+	sed -i -E '/^SUBDIRS\s*=/d' Makefile
+	echo -e '\n$(LIBHD):\n\t$(MAKE) -C src' >> Makefile
+	echo -e '\t$(CC) -shared $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) \' >> Makefile
+	echo -e '\t\t-Wl,--whole-archive $(LIBHD) -Wl,--no-whole-archive \' >> Makefile
+	echo -e '\t\t-Wl,-soname=$(LIBHD_SONAME) -o $(LIBHD_SO) $(SO_LIBS)' >> Makefile
+}
 
 termux_step_configure() {
 	echo 'touch changelog' > git2log


### PR DESCRIPTION
```
make: *** No rule to make target '[TERMUX_PKG_SRCDIR]/src/libhd.a', needed by 'hwinfo'.  Stop.
```

Fixes #297.